### PR TITLE
Fixes #7: chue color returns chue response

### DIFF
--- a/scripts/chue.coffee
+++ b/scripts/chue.coffee
@@ -31,7 +31,8 @@ module.exports = (robot) ->
 
     robot.http("https://gadgetlab.chnet/chue/color/#{lamp}/#{colour}")
         .get() (err, res, body) ->
-            msg.emote body
+            if res.statusCode == 200
+              msg.emote body
 
   robot.respond /bvoranje/i, (msg) ->
     robot.http("https://gadgetlab.chnet/chue/oranje")

--- a/scripts/chue.coffee
+++ b/scripts/chue.coffee
@@ -25,13 +25,13 @@ module.exports = (robot) ->
         .get() (err, res, body) ->
             msg.emote "Put on a colourloop at CH"
 
-  robot.respond /chue colou?r (\d)? ?#?([a-fA-F0-9]{6})/i, (msg) ->
+  robot.respond /chue colou?r (\d)? ?#?(.*)/i, (msg) ->
     lamp = if msg.match[1] is undefined then "all" else msg.match[1]
     colour = msg.match[2]
 
     robot.http("https://gadgetlab.chnet/chue/color/#{lamp}/#{colour}")
         .get() (err, res, body) ->
-            msg.emote "Changed colour of lamps (#{lamp}) to ##{colour}"
+            msg.emote body
 
   robot.respond /bvoranje/i, (msg) ->
     robot.http("https://gadgetlab.chnet/chue/oranje")


### PR DESCRIPTION
Adds support for sending friendly color names to florrie. Florrie will now also forward the response from chue, so that after https://github.com/WISVCH/chue/pull/12 has been merged, `florrie chue color red` will return the matched hex code.
