### PR TITLE
Properly link owls to `i.imgur.com` urls

### DIFF
--- a/scripts/superbowl.coffee
+++ b/scripts/superbowl.coffee
@@ -10,6 +10,7 @@ owls = {
 }
 
 timeout = 24 * 60 * 60 * 1000   # 1 day
+imgurRegex = /https?:\/\/(?:www\.)?(?:i\.)?imgur\.com\/(.*?)(?:[#\/\.].*|$)/i
 
 module.exports = (robot) ->
   robot.respond /(?:superb[\s]*)?(?:owl)(?:[\s]+me)?/i, (msg) ->
@@ -26,8 +27,12 @@ getOwl = (msg) ->
         getOwl(msg)
     return
   owl = msg.random owls.data.data.children.filter((item) ->
-    if item == null
-      return false
-    return item.data.domain == 'i.imgur.com' || item.data.domain == 'imgur.com')
-  msg.send owl.data.url
-  
+    return item.data.url.match(imgurRegex) != null
+  ).map((item) ->
+    match = item.data.url.match imgurRegex
+    if match != null
+      return match[1]
+    return null   # should be impossible
+  )
+  if owl != null
+    msg.send 'https://i.imgur.com/' + owl + '.gifv'


### PR DESCRIPTION
Sometimes this script would link to `imgur.com/ID` which is just some webpage which the Slack client won't automatically load as an image.
