### PR TITLE
Removed node_js 0.8 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
+  - "4.1"
+  - "4.0"
+  - "0.12"
   - "0.11"
   - "0.10"
-matrix:
-  include:
-    - node_js: "0.8"
-      # old versions of NPM don't include support for `^` dependency prefixes in package.json
-      before_install: npm update -g npm


### PR DESCRIPTION
Added all versions between 0.10 and 4.1.
