### PR TITLE
Remove broken facepalm script

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -3,7 +3,6 @@
   "xkcd.coffee",
   "applause.coffee",
   "beerme.coffee",
-  "facepalm.coffee",
   "trollicon.coffee",
   "lmgtfy.coffee"
 ]


### PR DESCRIPTION
The domain it uses has expired (or at least the script is not hosted anymore), and the `hubot-scripts` repo hosting this script is deprecated, so let's just remove it for now.
