### PR TITLE
Add empty callback to pubtimealert

### DIFF
--- a/scripts/pubtimealert.coffee
+++ b/scripts/pubtimealert.coffee
@@ -26,7 +26,7 @@ module.exports = (robot) ->
       robot.messageRoom ROOM, "The /Pub is open! Have a beer! 🍻"
       if robot.adapterName == 'slack'
         robot.http("#{chueURL}alert?timeout=#{duration}")
-          .get()
+          .get() (err, res, body) ->
     null
     true
     TIMEZONE


### PR DESCRIPTION
Tested; but the (afaik) old problem with the certificates popped up again.

No idea how this was fixed on `marina` (@praseodym) but locally I had to set `NODE_TLS_REJECT_UNAUTHORIZED="0"`, otherwise the HTTP library would return this error

```
{ [Error: unable to verify the first certificate] code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' }
```
