### PR TITLE
Fix rounding error in pubtime

### DIFF
--- a/scripts/pubtime.coffee
+++ b/scripts/pubtime.coffee
@@ -21,7 +21,7 @@ module.exports = (robot) ->
       else
         hours = Math.floor(timeLeft / 60 / 60)
         minutes = Math.floor(timeLeft / 60) - hours * 60
-        seconds = timeLeft - hours * 3600 - minutes * 60
+        seconds = Math.round(timeLeft - hours * 3600 - minutes * 60)
 
         hourString = hours + " " + `((hours == 1) ? "hour" : "hours")`
         minuteString = minutes + " " + `((minutes == 1) ? "minute" : "minutes")`


### PR DESCRIPTION
Fixes the wonderful `Still 4 hours, 34 minutes and 57.001000000000204 seconds left... Hang on!` response.
