### PR TITLE
hubot-plusplus: raisins -> reasons

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hubot-irc": "~0.2.7",
     "hubot-maps": "0.0.2",
     "hubot-pandapanda": "jabbink/hubot-pandapanda",
-    "hubot-plusplus": "~1.2.3",
+    "hubot-plusplus-improved": "~1.2.6",
     "hubot-pokedex": "0.0.4",
     "hubot-pugme": "~0.1.0",
     "hubot-pugsofwesteros": "^1.0.3",


### PR DESCRIPTION
Via own repo as maintainers of `hubot-plusplus` don't see why this is annoying and totally not funny.
