### PR TITLE
Add installation instructions for new developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can test your hubot by running the following, however some plugins will not
 behave as expected unless the [environment variables](#configuration) they rely
 upon have been set.
 
-First of all, install the dependencies by running of these two commands:
+First of all, install the dependencies by running one of these two commands:
 
     % yarn
     % npm

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ You can test your hubot by running the following, however some plugins will not
 behave as expected unless the [environment variables](#configuration) they rely
 upon have been set.
 
+First of all, install the dependencies by running of these two commands:
+
+    % yarn
+    % npm
+
 You can start florrie locally by running:
 
     % bin/hubot


### PR DESCRIPTION
If you run `bin/hubot`, it looks for the `node_modules/` folder, but that requires installation of the dependencies. Therefore, add an explicit mention to install the node dependencies with yarn/npm.