### PR TITLE
Fix ical parsing

### DIFF
--- a/scripts/pubtimealert.js
+++ b/scripts/pubtimealert.js
@@ -30,7 +30,7 @@ module.exports = function(robot) {
     const todaysStartTime = now.getTime();
 
     try {
-      const calendar = await fetch('https://pub.etv.tudelft.nl/ical/feed/all');
+      const calendar = await fetch('https://pub.ewi.tudelft.nl/ical/feed/all');
       const calendarEvents = ical.parseICS((await calendar.text()).split('\n').map(_ => {return _.trim()}).join('\n'));
 
       const event = Object.values(calendarEvents)

--- a/scripts/pubtimealert.js
+++ b/scripts/pubtimealert.js
@@ -31,7 +31,7 @@ module.exports = function(robot) {
 
     try {
       const calendar = await fetch('https://pub.etv.tudelft.nl/ical/feed/all');
-      const calendarEvents = ical.parseICS(await calendar.text());
+      const calendarEvents = ical.parseICS((await calendar.text()).split('\n').map(_ => {return _.trim()}).join('\n'));
 
       const event = Object.values(calendarEvents)
           .filter(event => {


### PR DESCRIPTION
New pub ical format has lots of invalid whitespaces which the `ical` package hates; dirty way to strip these.
Actually tested this time.